### PR TITLE
fix: incorrect InstructionDisplay argument (xr → teleop_device)

### DIFF
--- a/scripts/imitation_learning/isaaclab_recorder/record_demos.py
+++ b/scripts/imitation_learning/isaaclab_recorder/record_demos.py
@@ -315,7 +315,7 @@ def setup_ui(label_text: str, env: gym.Env) -> InstructionDisplay:
     Returns:
         InstructionDisplay: The configured instruction display object
     """
-    instruction_display = InstructionDisplay(args_cli.xr)
+    instruction_display = InstructionDisplay(args_cli.teleop_device)
     if not args_cli.xr:
         window = EmptyWindow(env, "Instruction")
         with window.ui_window_elements["main_vstack"]:


### PR DESCRIPTION
After installing the repository, I ran the following command:

```
python scripts/imitation_learning/isaaclab_recorder/record_demos.py \
    --task RobotisLab-PickPlace-FFW-BG2-IK-Rel-v0 \
    --teleop_device keyboard \
    --dataset_file ./datasets/dataset.hdf5 \
    --num_demos 10 \
    --enable_cameras
```

I encountered the following error, and the simulation froze at the same time:

[Screencast from 11-13-2025 12:44:08 PM.webm](https://github.com/user-attachments/assets/b5a96f75-2c9e-4ffb-b597-8bdc5a1f2fb7)

```
Traceback (most recent call last):
  File "/home/j/robotis_lab/scripts/imitation_learning/isaaclab_recorder/record_demos.py", line 556, in <module>
    main()

  File "/home/j/robotis_lab/scripts/imitation_learning/isaaclab_recorder/record_demos.py", line 546, in main
    current_recorded_demo_count = run_simulation_loop(env, None, success_term, rate_limiter)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/j/robotis_lab/scripts/imitation_learning/isaaclab_recorder/record_demos.py", line 449, in run_simulation_loop
    instruction_display = setup_ui(label_text, env)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/j/robotis_lab/scripts/imitation_learning/isaaclab_recorder/record_demos.py", line 318, in setup_ui
    instruction_display = InstructionDisplay(args_cli.xr)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/j/IsaacLab/source/isaaclab_mimic/isaaclab_mimic/ui/instruction_display.py", line 24, in __init__
    self.teleop_device = teleop_device.lower()
                         ^^^^^^^^^^^^^^^^^^^
AttributeError: 'bool' object has no attribute 'lower'
```

To resolve this issue, I updated the argument passed to `InstructionDisplay` in `record_demos.py`.