### PR TITLE
Update Docker image repository to robotis/cyclo-lab

### DIFF
--- a/docker/container.sh
+++ b/docker/container.sh
@@ -181,7 +181,7 @@ clean_docker() {
     echo
     if [[ $REPLY =~ ^[Yy]$ ]]; then
         docker compose down cyclo_lab
-        docker rmi cyclolab/cyclo-lab${DOCKER_NAME_SUFFIX}:latest || true
+        docker rmi robotis/cyclo-lab${DOCKER_NAME_SUFFIX}:latest || true
         echo "[INFO] Cleanup complete"
     else
         echo "[INFO] Cleanup cancelled"

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -72,7 +72,7 @@ services:
   cyclo_lab:
     profiles: [ "base" ]
     env_file: .env.base
-    image: cyclolab/cyclo-lab${DOCKER_NAME_SUFFIX}:latest
+    image: robotis/cyclo-lab${DOCKER_NAME_SUFFIX}:latest
     container_name: cyclo_lab${DOCKER_NAME_SUFFIX}
     build:
       context: ../


### PR DESCRIPTION
## Summary

  This PR updates the Cyclo Lab Docker image repository from `cyclolab/cyclo-lab` to `robotis/cyclo-lab`.

  ## Changes

  - Updated the compose image reference to use `robotis/cyclo-lab:latest`
  - Updated the Docker cleanup command to remove `robotis/cyclo-lab:latest`