### PR TITLE
Bump cyclo_lab to 2.0.1 and update ai_sapiens submodule

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package cyclo_lab
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.0.1 (2026-07-22)
+------------------
+* Updated the ``ai_sapiens`` submodule pointer.
+* Contributors: Woojin Wie
+
 2.0.0 (2026-06-26)
 ------------------
 * Renamed the extension package from ``robotis_lab`` to ``cyclo_lab``.

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -13,7 +13,7 @@ ENV ISAACSIM_VERSION=${ISAACSIM_VERSION_ARG}
 SHELL ["/bin/bash", "-c"]
 
 # Adds labels to the Dockerfile
-LABEL version="2.0.0"
+LABEL version="2.0.1"
 LABEL description="Dockerfile for building and running the Isaac Lab and Cyclo Lab framework inside Isaac Sim container image."
 
 # Arguments

--- a/source/cyclo_lab/config/extension.toml
+++ b/source/cyclo_lab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Semantic Versioning is used: https://semver.org/
-version = "2.0.0"
+version = "2.0.1"
 
 # Description
 title =  "cyclo_lab Tasks"


### PR DESCRIPTION
## Summary

- Update the `ai_sapiens` submodule to the recreated repository's current `main` commit.
- Bump the Cyclo Lab extension and Docker image version from `2.0.0` to `2.0.1`.
- Add a `2.0.1` changelog entry.

## Changes

- `third_party/ai_sapiens`: `0958865` -> `eaf7579`
- `source/cyclo_lab/config/extension.toml`: `2.0.0` -> `2.0.1`
- `docker/Dockerfile.base`: `2.0.0` -> `2.0.1`
- `CHANGELOG.rst`: document the submodule refresh.

## Validation

- Confirmed the extension TOML parses and declares version `2.0.1`.
- Checked the diff for whitespace errors.
