### PR TITLE
Fix K1 ankle pitch actuator and nominal sim2real export

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package cyclo_lab
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.0.2 (2026-07-24)
+------------------
+* Updated the K1 ankle pitch actuator configuration to use the Q80 actuator.
+* Added nominal joint positions to the sim-to-real configuration export.
+* Updated the ``ai_sapiens`` submodule pointer.
+* Contributors: Kiwoong Park
+
 2.0.1 (2026-07-22)
 ------------------
 * Updated the ``ai_sapiens`` submodule pointer.

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -13,7 +13,7 @@ ENV ISAACSIM_VERSION=${ISAACSIM_VERSION_ARG}
 SHELL ["/bin/bash", "-c"]
 
 # Adds labels to the Dockerfile
-LABEL version="2.0.1"
+LABEL version="2.0.2"
 LABEL description="Dockerfile for building and running the Isaac Lab and Cyclo Lab framework inside Isaac Sim container image."
 
 # Arguments

--- a/source/cyclo_lab/config/extension.toml
+++ b/source/cyclo_lab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Semantic Versioning is used: https://semver.org/
-version = "2.0.1"
+version = "2.0.2"
 
 # Description
 title =  "cyclo_lab Tasks"

--- a/source/cyclo_lab/cyclo_lab/assets/robots/K1_rev1.py
+++ b/source/cyclo_lab/cyclo_lab/assets/robots/K1_rev1.py
@@ -123,10 +123,18 @@ K1_REV1_CFG = ArticulationCfg(
                 ".*_knee_joint": 0.01,
             },
         ),
-        "feet": ImplicitActuatorCfg(
+        "ankle_pitch": ImplicitActuatorCfg(
+            effort_limit_sim=MAX_TORQUE_QC080_240_R020_RE,
+            velocity_limit_sim=MAX_SPEED_QC080_240_R020_RE,
+            joint_names_expr=[".*_ankle_pitch_joint"],
+            stiffness=20.0,
+            damping=2.0,
+            armature=0.01,
+        ),
+        "ankle_roll": ImplicitActuatorCfg(
             effort_limit_sim=MAX_TORQUE_QC060_200_R020_RE,
             velocity_limit_sim=MAX_SPEED_QC060_200_R020_RE,
-            joint_names_expr=[".*_ankle_pitch_joint", ".*_ankle_roll_joint"],
+            joint_names_expr=[".*_ankle_roll_joint"],
             stiffness=20.0,
             damping=2.0,
             armature=0.01,
@@ -265,8 +273,16 @@ K1_REV1_INERTIA_TUNED_CFG = ArticulationCfg(
                 ".*_knee_joint": ARMATURE_QC080_240_R020_RE,
             },
         ),
-        "feet": ImplicitActuatorCfg(
-            joint_names_expr=[".*_ankle_pitch_joint", ".*_ankle_roll_joint"],
+        "ankle_pitch": ImplicitActuatorCfg(
+            joint_names_expr=[".*_ankle_pitch_joint"],
+            effort_limit_sim=MAX_TORQUE_QC080_240_R020_RE,
+            velocity_limit_sim=MAX_SPEED_QC080_240_R020_RE,
+            stiffness=2.0 * STIFFNESS_QC080_240_R020_RE,
+            damping=2.0 * DAMPING_QC080_240_R020_RE,
+            armature=2.0 * ARMATURE_QC080_240_R020_RE,
+        ),
+        "ankle_roll": ImplicitActuatorCfg(
+            joint_names_expr=[".*_ankle_roll_joint"],
             effort_limit_sim=MAX_TORQUE_QC060_200_R020_RE,
             velocity_limit_sim=MAX_SPEED_QC060_200_R020_RE,
             stiffness=2.0 * STIFFNESS_QC060_200_R020_RE,

--- a/source/cyclo_lab/cyclo_lab/utils/export_sim2real_cfg.py
+++ b/source/cyclo_lab/cyclo_lab/utils/export_sim2real_cfg.py
@@ -152,6 +152,22 @@ def _collect_export_context(env: ManagerBasedRLEnv) -> _ExportContext:
     )
 
 
+def _default_joint_position_by_name(context: _ExportContext) -> dict[str, Any]:
+    """Return nominal joint positions, excluding per-environment domain randomization."""
+    nominal = getattr(context.asset.data, "default_joint_pos_nominal", None)
+    if nominal is None:
+        nominal = context.asset.data.default_joint_pos[0]
+    if nominal.ndim == 2:
+        nominal = nominal[0]
+    values = _tensor_to_list(nominal)
+    if len(values) != len(context.asset_joint_names):
+        raise ValueError(
+            f"Nominal default joint positions have {len(values)} values for "
+            f"{len(context.asset_joint_names)} asset joints."
+        )
+    return dict(zip(context.asset_joint_names, values))
+
+
 def _export_joint_properties(context: _ExportContext) -> dict[str, _CfgDict]:
     asset = context.asset
     joint_names = context.policy_joint_names
@@ -160,7 +176,8 @@ def _export_joint_properties(context: _ExportContext) -> dict[str, _CfgDict]:
     joint_properties = {}
     stiffness = _tensor_to_list(asset.data.default_joint_stiffness[0, joint_ids])
     damping = _tensor_to_list(asset.data.default_joint_damping[0, joint_ids])
-    default_joint_pos = _tensor_to_list(asset.data.default_joint_pos[0, joint_ids])
+    default_position_by_name = _default_joint_position_by_name(context)
+    default_joint_pos = [default_position_by_name[joint_name] for joint_name in joint_names]
     for joint_name, default_position, joint_stiffness, joint_damping in zip(
         joint_names, default_joint_pos, stiffness, damping
     ):
@@ -206,9 +223,15 @@ def _action_scale(term_cfg, action_term) -> list[Any]:
     return _tensor_to_list(action_term._scale[0])
 
 
-def _action_offset(term_cfg, action_term) -> list[Any]:
+def _action_offset(
+    term_cfg,
+    action_term,
+    action_joint_names: list[str],
+    context: _ExportContext,
+) -> list[Any]:
     if term_cfg.use_default_offset:
-        return _tensor_to_list(action_term._offset[0])
+        default_position_by_name = _default_joint_position_by_name(context)
+        return [default_position_by_name[joint_name] for joint_name in action_joint_names]
     return [0.0 for _ in range(action_term.action_dim)]
 
 
@@ -232,7 +255,7 @@ def _export_action_term(action_name: str, action_term, context: _ExportContext) 
         term_cfg.clip = _reorder_by_joint_name(clip, action_joint_names, policy_joint_names, "action clip")
 
     if hasattr(term_cfg, "use_default_offset"):
-        offset = _action_offset(term_cfg, action_term)
+        offset = _action_offset(term_cfg, action_term, action_joint_names, context)
         term_cfg.offset = _reorder_by_joint_name(offset, action_joint_names, policy_joint_names, "action offset")
 
     return _strip_action_cfg_for_export(term_cfg.to_dict())


### PR DESCRIPTION
## Summary
- Configure the K1 ankle pitch joint as a Q80 actuator while keeping ankle roll on Q60.
- Split ankle pitch and roll into separate actuator groups in both standard and inertia-tuned configurations.
- Export nominal joint positions to `sim2real.yaml` instead of per-environment randomized home offsets.
- Keep `joint_properties.default_position` and action offsets consistent.
## Validation
- Generated `sim2real.yaml` using `Cyclo-Mimic-K1-Rev1-Dance1`.
- Verified that exported default positions and action offsets match the nominal pose.
- Confirmed that startup-randomized home offsets are not included in the exported configuration.